### PR TITLE
hotfix for loading server ip dynamically

### DIFF
--- a/web/content/debug/getServerIP.php
+++ b/web/content/debug/getServerIP.php
@@ -1,4 +1,2 @@
 <?php
-$host = gethostname();
-$ip = gethostbyname($host);
-echo $ip;
+echo ($_SERVER['HTTP_HOST']);


### PR DESCRIPTION
gethostbyname($host) returns wrong network interface ip